### PR TITLE
Be more permissive when setting the utf8 locale

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -9,7 +9,12 @@ from difflib import SequenceMatcher
 from diff_match_patch import diff_match_patch
 import json
 import locale
-locale.setlocale(locale.LC_TIME, 'fr_FR.utf8')
+
+try:
+    locale.setlocale(locale.LC_TIME, 'fr_FR.utf8')
+except locale.Error:
+    locale.setlocale(locale.LC_TIME, 'fr_FR.utf-8')
+
 try:
     from .sort_articles import bister
 except:


### PR DESCRIPTION
It fixes a cross-platform compatibility bug:

Under macOS, `fr_FR.utf8` is unknown and must be replaced by `fr_FR.utf-8`

Fix #75