### PR TITLE
add live texts parsing to the CRON task

### DIFF
--- a/tlfp/format_data_for_frontend.py
+++ b/tlfp/format_data_for_frontend.py
@@ -22,9 +22,11 @@ def dump_success_log(output_dir, log):
         f.write(log)
     textid = output_dir.split('/')[-1]
     api_dir = output_dir.replace('/' + textid, '')
-    err_log = os.path.join(api_dir, 'logs', textid)
-    if os.path.exists(err_log):
-        os.remove(err_log)
+
+    for err_dir in ('logs', 'logs-encours'):
+        err_log = os.path.join(api_dir, err_dir, textid)
+        if os.path.exists(err_log):
+            os.remove(err_log)
 
 
 def process(dos, OUTPUT_DIR, log=io.StringIO(), skip_already_done=False):

--- a/tlfp/generate_dossiers_csv.py
+++ b/tlfp/generate_dossiers_csv.py
@@ -82,15 +82,21 @@ for dos, path in dossiers:
         total_promulgues += 1
 
 erreurs = len(glob.glob(os.path.join(API_DIRECTORY, 'logs/*')))
+erreurs_encours = len(glob.glob(os.path.join(API_DIRECTORY, 'logs-encours/*')))
+
+total_encours = total_doslegs - total_promulgues
+maximum = total_promulgues + erreurs  # assume qu'aucun en cours n'echoue
 
 print(total_doslegs, 'doslegs in csv')
 print(total_promulgues, 'promulgués')
+print(total_encours, 'en cours')
 print(erreurs, 'parsings échoués')
-print('%.1f%s OK' % (100*total_promulgues/(total_promulgues + erreurs), '%'))
+print('%.1f%s OK' % (100*total_promulgues/(total_promulgues + erreurs), '%'), 'de promulgués qui passent')
+print('%.1f%s OK' % (100*total_encours/(total_encours + erreurs_encours), '%'), 'de textes en cours qui passent')
 
 home_json_final = {
     "total": total_promulgues,
-    "encours": total_doslegs - total_promulgues,
+    "encours": total_encours,
     "maximum": total_promulgues + erreurs
 }
 home_json_data.sort(key=lambda x: -x['total_amendements'])

--- a/tlfp/generate_dossiers_csv.py
+++ b/tlfp/generate_dossiers_csv.py
@@ -81,20 +81,23 @@ for dos, path in dossiers:
     if dos.get('url_jo'):
         total_promulgues += 1
 
+total_encours = total_doslegs - total_promulgues
+
 erreurs = len(glob.glob(os.path.join(API_DIRECTORY, 'logs/*')))
 erreurs_encours = len(glob.glob(os.path.join(API_DIRECTORY, 'logs-encours/*')))
 
-total_encours = total_doslegs - total_promulgues
-maximum = total_promulgues + erreurs  # assume qu'aucun en cours n'echoue
+max_promulgues = total_promulgues + erreurs
+max_encours = total_encours + erreurs_encours
+maximum = max_promulgues + max_encours
 
 print(total_doslegs, 'doslegs in csv')
-print('%.1f%s (%d/%d)' % (100*total_promulgues/(total_promulgues + erreurs), '%', total_promulgues, total_promulgues + erreurs), 'de promulgués qui passent')
-print('%.1f%s (%d/%d)' % (100*total_encours/(total_encours + erreurs_encours), '%', total_encours, total_encours + erreurs_encours), 'de textes en cours qui passent')
+print('%.1f%s (%d/%d)' % (100*total_promulgues/max_promulgues, '%', total_promulgues, max_promulgues), 'de promulgués qui passent')
+print('%.1f%s (%d/%d)' % (100*total_encours/max_encours, '%', total_encours, max_encours), 'de textes en cours qui passent')
 
 home_json_final = {
     "total": total_promulgues,
     "encours": total_encours,
-    "maximum": total_promulgues + erreurs
+    "maximum": max_promulgues,
 }
 home_json_data.sort(key=lambda x: -x['total_amendements'])
 home_json_final["focus"] = {

--- a/tlfp/generate_dossiers_csv.py
+++ b/tlfp/generate_dossiers_csv.py
@@ -88,11 +88,8 @@ total_encours = total_doslegs - total_promulgues
 maximum = total_promulgues + erreurs  # assume qu'aucun en cours n'echoue
 
 print(total_doslegs, 'doslegs in csv')
-print(total_promulgues, 'promulgués')
-print(total_encours, 'en cours')
-print(erreurs, 'parsings échoués')
-print('%.1f%s OK' % (100*total_promulgues/(total_promulgues + erreurs), '%'), 'de promulgués qui passent')
-print('%.1f%s OK' % (100*total_encours/(total_encours + erreurs_encours), '%'), 'de textes en cours qui passent')
+print('%.1f%s (%d/%d)' % (100*total_promulgues/(total_promulgues + erreurs), '%', total_promulgues, total_promulgues + erreurs), 'de promulgués qui passent')
+print('%.1f%s (%d/%d)' % (100*total_encours/(total_encours + erreurs_encours), '%', total_encours, total_encours + erreurs_encours), 'de textes en cours qui passent')
 
 home_json_final = {
     "total": total_promulgues,

--- a/tlfp/parse_one.py
+++ b/tlfp/parse_one.py
@@ -1,4 +1,4 @@
-import sys, io, os, traceback
+import sys, contextlib, io, os, traceback
 
 from senapy.dosleg.parser import parse as senapy_parse
 from anpy.dossier_like_senapy import parse as anpy_parse
@@ -11,37 +11,26 @@ from .tools.json2arbo import mkdirs
 from .tools.download_groupes import process as download_groupes
 from .tools.download_lois_dites import process as download_lois_dites
 from .tools.download_AN_opendata import process as download_AN_opendata
-from .tools.common import debug_file, log_print
+from .tools.common import debug_file
 from .merge import merge_senat_with_an
 
 
-class ParsingFailedException(Exception):
-    def __init__(self, exception, logfile):
-        super().__init__()
-        self.root_exception = exception
-        self.logfile = logfile
-
-
-def download_senat(url, log=sys.stderr):
-    print('  [] download SENAT version')
-    resp = download(url)
-    if resp.status_code != 200:
-        print('WARNING: Invalid response -', resp.status_code)
-        return
-    html = resp.text
-    print('  [] parse SENAT version')
+def download_senat(url, log=sys.stderr, verbose=True):
+    if verbose: print('  [] download SENAT version')
+    html = download(url).text
+    if verbose: print('  [] parse SENAT version')
     senat_dos = senapy_parse(html, url, logfile=log)
     debug_file(senat_dos, 'debug_senat_dos.json')
     return senat_dos
 
 
-def download_an(url, cached_opendata_an, url_senat=False, log=sys.stderr):
-    print('  [] download AN version')
-    print('  [] parse AN version')
+def download_an(url, cached_opendata_an, url_senat=False, log=sys.stderr, verbose=True):
+    if verbose: print('  [] download AN version')
+    if verbose: print('  [] parse AN version')
     # TODO: do both instead of first
-    results = anpy_parse(url, logfile=log, cached_opendata_an=cached_opendata_an)
+    results = anpy_parse(url, logfile=log, verbose=verbose, cached_opendata_an=cached_opendata_an)
     if not results:
-        print('     WARNING: AN DOS NOT FOUND', url)
+        if verbose: print('     WARNING: AN DOS NOT FOUND', url)
         return
     an_dos = results[0]
     if len(results) > 1:
@@ -50,7 +39,7 @@ def download_an(url, cached_opendata_an, url_senat=False, log=sys.stderr):
                 if result.get('url_dossier_senat') == url_senat:
                     an_dos = result
                     break
-        print('     WARNING: TOOK FIRST DOSLEG BUT THERE ARE %d OF THEM' % len(results))
+        if verbose: print('     WARNING: TOOK FIRST DOSLEG BUT THERE ARE %d OF THEM' % len(results))
 
     debug_file(an_dos, 'debug_an_dos.json')
     return an_dos
@@ -70,25 +59,25 @@ def are_same_doslegs(senat_dos, an_dos):
     return False
 
 
-def download_merged_dos(url, cached_opendata_an, log=sys.stderr):
+def download_merged_dos(url, cached_opendata_an, log=sys.stderr, verbose=True):
     """find dossier from url and returns (the_merged_dosleg, AN_dosleg, SENAT_dosleg)"""
     if not url.startswith('http') and ('pjl' in url or 'ppl' in url or 'plfss' in url):
         url = "http://www.senat.fr/dossier-legislatif/%s.html" % url
 
-    print(' -= DOSLEG URL:', url, '=-')
+    if verbose: print(' -= DOSLEG URL:', url, '=-')
 
     dos = None
     an_dos = None
     senat_dos = None
 
     if 'senat.fr' in url:
-        senat_dos = download_senat(url, log=log)
+        senat_dos = download_senat(url, verbose=verbose, log=log)
         if not senat_dos:
-            print('  /!\ INVALID SENAT DOS')
+            if verbose: print('  /!\ INVALID SENAT DOS')
             return None, None, None
         # Add AN version if there's one
         if 'url_dossier_assemblee' in senat_dos:
-            an_dos = download_an(senat_dos['url_dossier_assemblee'], cached_opendata_an, senat_dos['url_dossier_senat'], log=log)
+            an_dos = download_an(senat_dos['url_dossier_assemblee'], cached_opendata_an, senat_dos['url_dossier_senat'], verbose=verbose, log=log)
             if not an_dos:
                 return senat_dos, None, senat_dos
             if 'url_dossier_senat' in an_dos:
@@ -97,18 +86,48 @@ def download_merged_dos(url, cached_opendata_an, log=sys.stderr):
         else:
             dos = senat_dos
     elif 'assemblee-nationale.fr' in url:
-        dos = an_dos = download_an(url, cached_opendata_an, log=log)
+        an_dos = download_an(url, cached_opendata_an, verbose=verbose, log=log)
         # Add senat version if there's one
         if 'url_dossier_senat' in an_dos:
             senat_dos = download_senat(an_dos['url_dossier_senat'], log=log)
-            if senat_dos:
-                dos = merge_senat_with_an(senat_dos, an_dos)
+            dos = merge_senat_with_an(senat_dos, an_dos)
+        else:
+            dos = an_dos
     else:
-        print(' INVALID URL:', url)
+        if verbose: print(' INVALID URL:', url)
     return dos, an_dos, senat_dos
 
 
+@contextlib.contextmanager
+def log_print(file):
+    # capture all outputs to a log file while still printing it
+    class Logger:
+        def __init__(self, file):
+            self.terminal = sys.stdout
+            self.log = file
+            self.only_log = False
+
+        def write(self, message):
+            self.terminal.write(message)
+            self.log.write(message)
+
+        def __getattr__(self, attr):
+            return getattr(self.terminal, attr)
+
+    logger = Logger(file)
+
+    _stdout = sys.stdout
+    _stderr = sys.stderr
+    sys.stdout = logger
+    sys.stderr = logger
+    yield logger.log
+    sys.stdout = _stdout
+    sys.stderr = _stderr
+
+
 def dump_error_log(url, exception, logdir, log):
+    log = log.getvalue() + '\n' + ''.join(traceback.format_tb(exception.__traceback__))
+
     url_id = url.replace('/', '')
     if 'assemblee-nationale' in url:
         url_id = "%s-%s" % parse_national_assembly_url(url)
@@ -118,39 +137,43 @@ def dump_error_log(url, exception, logdir, log):
     mkdirs(logdir)
     logfile = os.path.join(logdir, url_id)
 
-    with open(logfile, 'w') as f:
-        f.write(log.getvalue())
-
-    print('[error] parsing of', url, 'failed. Details in', logfile)
-
-    raise ParsingFailedException(exception, logfile)
+    print('[error] parsing', url, 'failed. Details in', logfile)
+    open(logfile, 'w').write(log)
 
 
 def process(API_DIRECTORY, url):
+    disable_cache = '--enable-cache' not in sys.argv
     only_promulgated = '--only-promulgated' in sys.argv
-    quiet = '--quiet' in sys.argv
-    if '--enable-cache' in sys.argv:
+    verbose = '--quiet' not in sys.argv
+    if not disable_cache:
         enable_requests_cache()
-
-    with log_print(only_log=quiet) as log:
+    dos = None
+    with log_print(io.StringIO()) as log:
         try:
-            print('======')
-            print(url)
+            if verbose:
+                print('======')
+                print(url)
 
             # download the AN open data or just retrieve the last stored version
             opendata_an = download_AN_opendata(API_DIRECTORY)
 
-            dos, an_dos, senat_dos = download_merged_dos(url, opendata_an, log=log)
+            dos, an_dos, senat_dos = download_merged_dos(url, opendata_an, log=log, verbose=verbose)
             if not dos:
-                raise Exception('Nothing found at %s' % url)
-
-            find_anomalies([dos])
-
-            if not dos.get('url_jo') and only_promulgated:
-                print('    ----- passed: no JO link')
                 return
 
-            print('        title:', dos.get('long_title'))
+            if verbose:
+                print('        title:', dos.get('long_title'))
+            find_anomalies([dos], verbose=verbose)
+
+            if not dos.get('url_jo') and only_promulgated:
+                if verbose:
+                    print('    ----- passed: no JO link')
+                return
+
+            if not verbose:
+                print()
+                print('======')
+                print(url)
 
             debug_file(dos, 'debug_dos.json')
 
@@ -167,16 +190,15 @@ def process(API_DIRECTORY, url):
 
             print('  [] format data for the frontend')
             format_data_for_frontend.process(dos_with_texts, API_DIRECTORY, log=log)
-            return dos
-        except KeyboardInterrupt as e:  # bypass the error log dump when doing Ctrl-C
+        except KeyboardInterrupt as e:
             raise e
         except Exception as e:
-            print(*traceback.format_tb(e.__traceback__), e, sep='', file=log)
             # dump log for each failed doslegs in logs/
             logdir = os.path.join(API_DIRECTORY, 'logs')
             if dos and not dos.get('url_jo'):
                 logdir = os.path.join(API_DIRECTORY, 'logs-encours')
             dump_error_log(url, e, logdir, log)
+            raise e
 
 
 if __name__ == '__main__':

--- a/tlfp/parse_one.py
+++ b/tlfp/parse_one.py
@@ -125,7 +125,7 @@ def log_print(file):
     sys.stderr = _stderr
 
 
-def dump_error_log(url, exception, api_dir, log):
+def dump_error_log(url, exception, logdir, log):
     log = log.getvalue() + '\n' + ''.join(traceback.format_tb(exception.__traceback__))
 
     url_id = url.replace('/', '')
@@ -134,8 +134,8 @@ def dump_error_log(url, exception, api_dir, log):
     elif 'senat.fr' in url:
         url_id = url.split('/')[-1].replace('.html', '')
 
-    mkdirs(os.path.join(api_dir, 'logs'))
-    logfile = os.path.join(api_dir, 'logs', url_id)
+    mkdirs(logdir)
+    logfile = os.path.join(logdir, url_id)
 
     print('[error] parsing', url, 'failed. Details in', logfile)
     open(logfile, 'w').write(log)
@@ -147,6 +147,7 @@ def process(API_DIRECTORY, url):
     verbose = '--quiet' not in sys.argv
     if not disable_cache:
         enable_requests_cache()
+    dos = None
     with log_print(io.StringIO()) as log:
         try:
             if verbose:
@@ -193,7 +194,10 @@ def process(API_DIRECTORY, url):
             raise e
         except Exception as e:
             # dump log for each failed doslegs in logs/
-            dump_error_log(url, e, API_DIRECTORY, log)
+            logdir = os.path.join(API_DIRECTORY, 'logs')
+            if dos and not dos.get('url_jo'):
+                logdir = 'logs-encours'
+            dump_error_log(url, e, logdir, log)
             raise e
 
 

--- a/tlfp/parse_one.py
+++ b/tlfp/parse_one.py
@@ -196,7 +196,7 @@ def process(API_DIRECTORY, url):
             # dump log for each failed doslegs in logs/
             logdir = os.path.join(API_DIRECTORY, 'logs')
             if dos and not dos.get('url_jo'):
-                logdir = 'logs-encours'
+                logdir = os.path.join(API_DIRECTORY, 'logs-encours')
             dump_error_log(url, e, logdir, log)
             raise e
 

--- a/update_promulgues.sh
+++ b/update_promulgues.sh
@@ -7,6 +7,8 @@ pyenv activate lafabrique
 DATADIR=data
 
 senapy-cli doslegs_urls --min-year=$((`date +%Y`)) | tlfp-parse-many $DATADIR --only-promulgated --quiet
+senapy-cli doslegs_urls --in-discussion | tlfp-parse-many $DATADIR --quiet
+anpy-cli doslegs_urls --in-discussion | tlfp-parse-many $DATADIR --quiet
 
 echo
 python tlfp/generate_dossiers_csv.py $DATADIR

--- a/update_promulgues.sh
+++ b/update_promulgues.sh
@@ -6,8 +6,15 @@ pyenv activate lafabrique
 
 DATADIR=data
 
+echo "Parsing new promulgated texts..."
 senapy-cli doslegs_urls --min-year=$((`date +%Y`)) | tlfp-parse-many $DATADIR --only-promulgated --quiet
+
+echo
+echo "Parsing texts in discussion in the Senate..."
 senapy-cli doslegs_urls --in-discussion | tlfp-parse-many $DATADIR --quiet
+
+echo
+echo "Parsing texts in discussion in the National Assembly..."
 anpy-cli doslegs_urls --in-discussion | tlfp-parse-many $DATADIR --quiet
 
 echo


### PR DESCRIPTION
### Stats

- 4/4 texts passing for `senapy-cli doslegs_urls --in-discussion`
- 2/4 texts passing for `anpy-cli doslegs_urls --in-discussion`
  - explanation for [avenir professionel](http://www.assemblee-nationale.fr/dyn/15/dossiers/alt/choix_avenir_professionnel) failing for example: an intermediary text is really missing (161)
- 265/298 texts passing for `senapy-cli doslegs_urls --min-year=2018` (88%)

#####  Errors stats (WIP)

```console
tail -n 1 data/logs-encours/* | grep -v '^==>' | grep . | sort | uniq --count | sort -rn
     16     data = step.get('texte.json')
      3     if step['date'] > date:
      2     raise Exception('[complete_articles] Fatal error')
      1     raise Exception('[parse_texts] Invalid response %s' % url)
      1     if dic.get('titre') and dic.get('titre') == article.get('titre') and 'source_text' not in article:
```
### Blocking problems

- [x] ~In `generate_dossiers_csv.py`, the count of the maximum promulgated texts we can support assumed there's no live texts failing (counting directly the number of failing cases in `logs/`)~
    * ~To keep the count correct we need to improve on that~ Done in this PR

- Make it clear the text is in progress in the UI
    * [x] ~parse futur steps in senapy~ Done in https://github.com/regardscitoyens/senapy/commit/484d818fef4ec236e0a441eb99c3b15ddee0be1d
### Possible improvements

- [ ] Deduplication of the urls but I consider this an optimization for later **(issue 72)**
- [x] ~Improved formatting of the CRON to distinguish the current texts and the promulgated ones~ Done in this PR
- [x] **`--in-discussion` should include the texts in the past (work to be done on anpy/senapy)**
   - possible solution: Take all the texts discussed in the last month and the ones discussed in the future by parsing the agenda
 - [ ] add to reparse_all.sh **(done by "Handle non promulgated texts already parsed in data")**

<hr>

 - parallelize to make it faster ?
- [ ] tests for texts in discussion #101
- [x] In the merge, we can ignore steps only in the AN-side, they should be merged too if we want the live to be really up-to-date 4688ba9dbcd348ffd53cc28f99b8c8aeb4228bd1

<hr>

See also: [Milestone on the frontend](https://github.com/regardscitoyens/the-law-factory/milestone/10)